### PR TITLE
Fixed create crashing when passed --watch

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -222,7 +222,7 @@ function handleCreate (yargs) {
     function createToken () {
         var config = Webtask.configFile();
         
-        config.load()
+        return config.load()
             .then(function (profiles) {
                 if (_.isEmpty(profiles)) {
                     throw new Error('You must create a profile to begin using '
@@ -269,7 +269,7 @@ function handleCreate (yargs) {
                         console.log(data.named_webtask_url);
                     }
                 }
-                
+
                 return data.token;
             })
             .catch(logError);


### PR DESCRIPTION
Typo in createToken(), wasn't returning the promise. Now watch works as expected.