### PR TITLE
Fixed incorrect welcome message

### DIFF
--- a/bin/profile.js
+++ b/bin/profile.js
@@ -143,7 +143,7 @@ function handleInit (argv) {
                     printProfile(argv.profile, profile);
                     
                     console.log(('Welcome to webtasks! Create one with '
-                        + '`wt token create`'.bold + '.').green);
+                        + '`wt create hello-world.js`'.bold + '.').green);
                 });
         })
         .catch(function (e) {


### PR DESCRIPTION
Post-init wt-cli said:

```
Welcome to webtasks! Create one with `wt token create`.
```

Which would be confusing.

Changed to:

```
Welcome to webtasks! Create one with `wt create hello-world.js`.
```