### PR TITLE
Throw an Error if the verification code isn't entered in five minutes.

### DIFF
--- a/bin/profile.js
+++ b/bin/profile.js
@@ -275,6 +275,7 @@ function getVerifiedProfile (argv) {
 
 function sendVerificationCode (phoneOrEmail) {
     var verifier = Webtask.createUserVerifier();
+    var FIVE_MINUTES = 1000 * 60 * 5;
 
     return verifier.requestVerificationCode(phoneOrEmail)
         .then(function (verifyFunc) {
@@ -282,8 +283,12 @@ function sendVerificationCode (phoneOrEmail) {
                 + phoneOrEmail + ' below.');
 
             return Promptly.promptAsync('Verification code:')
-                .then(verifyFunc);
-        })
+                .then(verifyFunc)
+                .timeout(FIVE_MINUTES, 'Verification code expired.')
+                .catch(function (e) {
+                    console.log('\n' + e.message.red + '\n');
+                });
+        });
 }
 
 function printProfile (name, profile, details) {


### PR DESCRIPTION
Fixes https://github.com/auth0/wt-cli/issues/12.

Don't leave the init prompt hanging forever (presumably the code sent expires at some point).