### PR TITLE
Fix GetTaskConfig  not always returning a promise

### DIFF
--- a/bin/utils/getTaskConfig.js
+++ b/bin/utils/getTaskConfig.js
@@ -92,10 +92,12 @@ function getTaskConfig (prevConfig, code) {
             prune(prevConfig.secret, secret);
 
         // Then there is no config specified, just supply all secrets in .env and get out early
-        return _.merge({}, prevConfig, {
+        return Bluebird.resolve(
+          _.merge({}, prevConfig, {
             secret: secret,
             param: param
-        });
+          })
+        );
     }
 
     tags


### PR DESCRIPTION
If you try to `create` a task without a JSDoc with the new `wt-cli` you'll get:

```
GetTaskConfig(...).then is not a function
```

Which is not good. This fixes that.