### PR TITLE
Fix history for cron tasks

### DIFF
--- a/bin/cron/history.js
+++ b/bin/cron/history.js
@@ -8,7 +8,7 @@ module.exports = Cli.createCommand('history', {
     plugins: [
         require('../_plugins/profile'),
     ],
-    outputGroups: {
+    optionGroups: {
         'Output options': {
             output: {
                 alias: 'o',
@@ -25,12 +25,12 @@ module.exports = Cli.createCommand('history', {
         'Pagination': {
             offset: {
                 description: 'Skip this many history entries.',
-                type: 'number',
+                type: 'int',
                 defaultValue: 0,
             },
             limit: {
                 description: 'Limit the result-set to this many entries.',
-                type: 'number',
+                type: 'int',
                 defaultValue: 20,
             },
         },


### PR DESCRIPTION
### Fetching history for cron tasks is not working

There is an issue if you try to fetch the history of executed cron task. It returns an error. It's a result of invalid settings defined for command line plugin (``structured-cli``).

- ``number`` instead of ``int`` for argument type
- ``outputGroups`` instead of ``optionGroups`` as a key value for grouped arguments

```bash
Uncaught error:  Cannot read property 'split' of undefined
TypeError: Cannot read property 'split' of undefined
```

![screen shot 2016-03-13 at 13 17 34](https://cloud.githubusercontent.com/assets/502493/13728621/c7b0e260-e91e-11e5-9964-29690cbb1434.png)