### PR TITLE
Support issuing webtask tokens associated with custom domain

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -86,7 +86,7 @@ module.exports = Cli.createCommand('create', {
             'host': {
                 description: 'Allow the webtask to be called using a custom domain name. Using this option requires proof of domain ownership. This can be done by adding a TXT record type to the DNS of the chosen domain. The value of the record must be `webtask:container:{container}`, where {container} is the webtask container name to be associated with the custom domain. Many such TXT records can be created as needed.',
                 type: 'string'
-            }
+            },
             'bundle-minify': {
                 description: 'Generate a minified production build',
                 type: 'boolean',

--- a/bin/create.js
+++ b/bin/create.js
@@ -83,6 +83,10 @@ module.exports = Cli.createCommand('create', {
                 description: 'Allow the webtask server to cache code. When disabled, your code will be loaded on each request by the webtask runtime environment, introducing additional latency. Leaving this disabled is useful while developing.',
                 type: 'boolean',
             },
+            'host': {
+                description: 'Allow the webtask to be called using a custom domain name. Using this option requires proof of domain ownership. This can be done by adding a TXT record type to the DNS of the chosen domain. The value of the record must be `webtask:container:{container}`, where {container} is the webtask container name to be associated with the custom domain. Many such TXT records can be created as needed.',
+                type: 'string'
+            }
         },
     },
     params: {

--- a/bin/wt
+++ b/bin/wt
@@ -85,7 +85,12 @@ Cli.run(cli)
         
         process.exit(7);
     })
-    // Code: 99
+    // Code: 8
+    .catch(_.matchesProperty('code', 'E_NOTAUTHORIZED'), function (err) {
+        console.error(Chalk.red(err.message));
+        
+        process.exit(8);
+    })    // Code: 99
     .catch(function (err) {
         console.error(Chalk.red('Uncaught error: ', err.message));
         console.error(err.stack);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,7 @@
 exports.cancelled = cancelled;
 exports.invalid = invalid;
 exports.notFound = notFound;
+exports.notAuthorized = notAuthorized;
 
 
 // Exported interface
@@ -15,6 +16,10 @@ function invalid(message, data) {
 
 function notFound(message, data) {
     return createError(message, 'E_NOTFOUND', data, notFound);
+}
+
+function notAuthorized(message, data) {
+    return createError(message, 'E_NOTAUTHORIZED', data, notAuthorized);
 }
 
 

--- a/lib/validateCreateArgs.js
+++ b/lib/validateCreateArgs.js
@@ -2,11 +2,17 @@ var Cli = require('structured-cli');
 var Path = require('path');
 var _ = require('lodash');
 
+var ip_regex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
+var dns_regex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 
 module.exports = validateCreateArgs;
 
 
 function validateCreateArgs(args) {
+    if (args.host && !args.host.match(ip_regex) && !args.host.match(dns_regex)) {
+        throw Cli.error.invalid('--host must specify a valid IP address or DNS domain name');
+    }
+
     if (args.capture && args.watch) {
         throw Cli.error.invalid('--watch is incompatible with --capture');
     }

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -7,6 +7,7 @@ var Fs = Bluebird.promisifyAll(require('fs'));
 var Sandbox = require('sandboxjs');
 var Superagent = require('superagent');
 var Watcher = require('filewatcher');
+var Errors = require('./errors')
 var _ = require('lodash');
 
 
@@ -51,8 +52,7 @@ function createWebtaskCreator(args, options) {
             .catch(function (e) { 
                 return e && e.statusCode === 403; 
             }, function (e) { 
-                console.log(Chalk.red('Error creating webtask: ' + e.message));
-                process.exit(1);
+                throw Errors.notAuthorized('Error creating webtask: ' + e.message);
             });
 
         return webtask$

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -1,6 +1,7 @@
 var Bluebird = require('bluebird');
 var Bundler = require('webtask-bundle');
 var Cli = require('structured-cli');
+var Chalk = require('chalk');
 var Concat = require('concat-stream');
 var Fs = Bluebird.promisifyAll(require('fs'));
 var Sandbox = require('sandboxjs');
@@ -43,8 +44,15 @@ function createWebtaskCreator(args, options) {
                     merge: args.merge,
                     parse: args.parse,
                     secrets: args.secrets,
-                    params: args.params
+                    params: args.params,
+                    host: args.host
                 });
+            })
+            .catch(function (e) { 
+                return e && e.statusCode === 403; 
+            }, function (e) { 
+                console.log(Chalk.red('Error creating webtask: ' + e.message));
+                process.exit(1);
             });
 
         return webtask$
@@ -102,7 +110,8 @@ function createWebtaskCreator(args, options) {
                 merge: args.merge,
                 parse: args.parse,
                 secrets: args.secrets,
-                params: args.params
+                params: args.params,
+                host: args.host
             });
 
             return webtask$

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",
@@ -38,7 +38,7 @@
     "open": "0.0.5",
     "pad": "^1.0.0",
     "promptly": "^0.2.1",
-    "sandboxjs": "^2.3.0",
+    "sandboxjs": "^2.4.0",
     "structured-cli": "^1.0.4",
     "superagent": "^1.7.2",
     "update-notifier": "^0.6.1",


### PR DESCRIPTION
This requires https://github.com/auth0/sandboxjs/pull/4 to be merged and published to NPM first, as well as a change to runtime covered by https://github.com/auth0/webtask/pull/14. 

This adds support for `--host` option to `wt create`, which allows specification of a custom domain name that can be used to run the created webtask. 

Sample successful usage: 

```
tomek@ubuntu:~/projects/wt-cli$ ./bin/wt create ../adhoc/hello.js --host serverless.host 
Webtask created

You can access your webtask at the following url:

http://serverless.host:8721/tjanczuk/hello?webtask_no_cache=1
```
(Note the URL of the webtask). 

Sample failed execution: 

```
tomek@ubuntu:~/projects/wt-cli$ ./bin/wt create ../adhoc/hello.js --host serverless.host --container foo
Error creating webtask: Unable to verify ownership of serverless.host domain. Please add a DNS record
with type TXT and value `webtask:container:foo` to the DNS of the serverless.host domain.
```

This is because the `serverless.host` DNS is only configured to be associated with `auth0` and `tjanczuk` container names:

![image](https://cloud.githubusercontent.com/assets/822369/14302020/554cd838-fb51-11e5-97a2-185512f2da38.png)
