### PR TITLE
Improved bundling experience

### DIFF
--- a/bin/bundle.js
+++ b/bin/bundle.js
@@ -1,0 +1,9 @@
+var Cli = require('structured-cli');
+
+
+var category = module.exports = Cli.createCategory('bundle', {
+    description: 'Operations for working with bundled webtasks',
+});
+
+category.addChild(require('./bundle/analyze'));
+category.addChild(require('./bundle/sync'));

--- a/bin/bundle/analyze.js
+++ b/bin/bundle/analyze.js
@@ -1,0 +1,31 @@
+var Chalk = require('chalk');
+var Checker = require('webtask-bundle/lib/checker');
+var Cli = require('structured-cli');
+var Path = require('path');
+
+
+module.exports = Cli.createCommand('analyze', {
+    description: 'Compare the module dependencies of your webtask with modules on the Webtask platform',
+    plugins: [
+        // require('../_plugins/profile'),
+    ],
+    params: {
+        'filename': {
+            description: 'Path to the webtask\'s code.',
+            type: 'string',
+            defaultValue: Path.join(process.cwd(), 'webtask.js'),
+        },
+    },
+    handler: handleBundleAnalyze,
+});
+
+
+// Command handler
+
+function handleBundleAnalyze(args) {
+    var check$ = Checker.check({
+        entry: args.filename,
+    });
+    
+    return check$.toPromise();
+}

--- a/bin/bundle/sync.js
+++ b/bin/bundle/sync.js
@@ -1,0 +1,41 @@
+var Chalk = require('chalk');
+var Checker = require('webtask-bundle/lib/checker');
+var Cli = require('structured-cli');
+var Path = require('path');
+
+
+module.exports = Cli.createCommand('sync', {
+    description: 'Update the version of each module in your package.json with the closest version available on webtask.io',
+    plugins: [
+        // require('../_plugins/profile'),
+    ],
+    optionGroups: {
+        'Synchronization options': {
+            interactive: {
+                alias: 'i',
+                description: 'Interactively prompt you for which packages to synchronize and which to leave untouched.',
+                type: 'boolean',
+            },
+        },
+    },
+    params: {
+        'filename': {
+            description: 'Path to the webtask\'s code.',
+            type: 'string',
+            defaultValue: Path.join(process.cwd(), 'webtask.js'),
+        },
+    },
+    handler: handleBundleAnalyze,
+});
+
+
+// Command handler
+
+function handleBundleAnalyze(args) {
+    var sync$ = Checker.sync({
+        entry: args.filename,
+        interactive: args.interactive,
+    });
+    
+    return sync$.toPromise();
+}

--- a/bin/wt
+++ b/bin/wt
@@ -38,6 +38,7 @@ cli.addChild(require('./profile'));
 cli.addChild(require('./cron'));
 cli.addChild(require('./logs'));
 cli.addChild(require('./token'));
+cli.addChild(require('./bundle'));
 
 
 Cli.run(cli)

--- a/lib/createWebtask.js
+++ b/lib/createWebtask.js
@@ -45,25 +45,25 @@ function createWebtask(args, options) {
     }
     
     function formatError(build, url) {
-        var output;
+        build.stats.errors = build.stats.errors.map(err => err.split('|').slice(0, -1).join('|'));
         
         if (args.watch) {
-            output = { generation: build.generation };
+            var output = { generation: build.generation };
             
             _.forEach(build.stats.errors, function (error) {
                 logError(output, 'Bundling failed: %s', error);
             });
         } else if (args.output === 'json') {
-            output = { url: url, name: build.webtask.claims.jtn, container: build.webtas.container };
+            var json = {
+                name: args.name,
+                container: args.profile.container,
+                errors: build.stats.errors,
+            };
             
-            if (args.showToken) {
-                output.token = build.webtask.token;
-            }
-            
-            logError(JSON.stringify(build.stats.errors, null, 2));
+            logError(JSON.stringify(json, null, 2));
         } else {
-            logError(Chalk.red('Bundling failed failed'));
-            build.stats.errors.forEach(logError);
+            logError(Chalk.red('Bundling failed'));
+            build.stats.errors.forEach(err => logError(err));
         }
     }
     

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "structured-cli": "^1.0.4",
     "superagent": "^1.7.2",
     "update-notifier": "^0.6.1",
-    "webtask-bundle": "^1.3.2"
+    "webtask-bundle": "^2.1.0"
   },
   "bin": {
     "wt": "./bin/wt",


### PR DESCRIPTION
* Upgrades to `webtask-bundle@2.1.0` that has some improvements to bundling.
* Adds the `wt bundle analyze` command which will show a helpful table of what is requested vs what is available on the platform (credit: @jcenturion).
* Adds the `wt bundle sync` command which will (optionally, interactively) synchronize your local `package.json`'s `dependencies` with what is available on the webtask platform.

These two new commands are helpful for understanding the ultimate contents of bundled webtasks and for avoiding module incompatibilities between locally installed module versions and webtask platform module versions.