### PR TITLE
Add `wt serve <filename>`

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -6,21 +6,55 @@ const Chalk = require('chalk');
 const Cli = require('structured-cli');
 const Path = require('path');
 const Runtime = require('webtask-runtime');
+const _ = require('lodash');
 
 
 module.exports = Cli.createCommand('serve', {
     description: 'Run a webtask as a local http server',
-    options: {
-        port: {
-            alias: 'p',
-            description: 'Port on which the webtask server will listen',
-            type: 'int',
-            defaultValue: 8080,
+    optionGroups: {
+        'Server options': {
+            port: {
+                alias: 'p',
+                description: 'Port on which the webtask server will listen',
+                type: 'int',
+                defaultValue: 8080,
+            },
+            'hostname': {
+                description: 'The hostname for the http listener',
+                type: 'string',
+                defaultValue: '0.0.0.0',
+            },
         },
-        'hostname': {
-            description: 'The hostname for the http listener',
-            type: 'string',
-            defaultValue: '0.0.0.0',
+        'Webtask creation': {
+            'secret': {
+                action: 'append',
+                alias: 's',
+                defaultValue: [],
+                description: 'Secret(s) exposed to your code as `secrets` on the webtask context object. These secrets will be encrypted and stored in a webtask token in such a way that only the webtask server is able to decrypt the secrets so that they may be exposed to your running webtask code.',
+                dest: 'secrets',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+            'param': {
+                action: 'append',
+                defaultValue: [],
+                description: 'Param(s) exposed to your code as `params` on the webtask context object. The properties will be signed and protected from interference but not encrypted.',
+                dest: 'params',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+            'no-merge': {
+                action: 'storeFalse',
+                defaultValue: true,
+                description: 'Disable automatic merging of the parsed body and secrets into the `data` field of the webtask context object. The parsed body (if available) will be on the `body` field and secrets on the `secrets` field.',
+                dest: 'mergeBody',
+            },
+            'no-parse': {
+                action: 'storeFalse',
+                defaultValue: true,
+                description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
+                dest: 'parseBody',
+            },
         },
     },
     params: {
@@ -37,12 +71,15 @@ module.exports = Cli.createCommand('serve', {
 // Command handler
 
 function handleWebtaskServe(args) {
+    parseKeyValList(args, 'secrets');
+    parseKeyValList(args, 'params');
+
     return Bluebird.using(createServer(), server => {
         return server.listenAsync(args.port, args.hostname)
             .tap(() => {
                 const address = server.address();
                 
-                console.log('Your webtask is now listening for %s traffic on %s:%s', address.family, address.address, address.port);
+                console.log('Your webtask is now listening for %s traffic on %s:%s', Chalk.green(address.family), Chalk.green.bold(address.address), Chalk.green.bold(address.port));
             })
             .delay(1000 * 60 * 30)
             .then(server => {
@@ -57,6 +94,10 @@ function handleWebtaskServe(args) {
             try {
                 const webtask = require(Path.resolve(process.cwd(), args.filename)); 
                 const server = Runtime.createServer(webtask, {
+                    parseBody: args.parseBody,
+                    mergeBody: args.mergeBody,
+                    secrets: args.secrets,
+                    params: args.params,
                     shortcutFavicon: true,
                 });
                 
@@ -74,5 +115,15 @@ function handleWebtaskServe(args) {
                     :   Bluebird.resolve();
             });
     }
+
+
+    function parseKeyValList(args, field) {
+        args[field] = _.reduce(args[field], function (acc, entry) {
+            var parts = entry.split('=');
+
+            return _.set(acc, parts.shift(), parts.join('='));
+        }, {});
+    }
+    
 }
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,0 +1,78 @@
+'use strict';
+
+
+const Bluebird = require('bluebird');
+const Chalk = require('chalk');
+const Cli = require('structured-cli');
+const Path = require('path');
+const Runtime = require('webtask-runtime');
+
+
+module.exports = Cli.createCommand('serve', {
+    description: 'Run a webtask as a local http server',
+    options: {
+        port: {
+            alias: 'p',
+            description: 'Port on which the webtask server will listen',
+            type: 'int',
+            defaultValue: 8080,
+        },
+        'hostname': {
+            description: 'The hostname for the http listener',
+            type: 'string',
+            defaultValue: '0.0.0.0',
+        },
+    },
+    params: {
+        'filename': {
+            description: 'The path to the webtask\'s source code',
+            type: 'string',
+            required: true,
+        },
+    },
+    handler: handleWebtaskServe,
+});
+
+
+// Command handler
+
+function handleWebtaskServe(args) {
+    return Bluebird.using(createServer(), server => {
+        return server.listenAsync(args.port, args.hostname)
+            .tap(() => {
+                const address = server.address();
+                
+                console.log('Your webtask is now listening for %s traffic on %s:%s', address.family, address.address, address.port);
+            })
+            .delay(1000 * 60 * 30)
+            .then(server => {
+                console.log('Automatically shutting down your webtask server after 30m');
+            });
+    })
+        .timeout(1000 * 60 * 30);
+    
+
+    function createServer() {
+        const promise$ = new Bluebird((resolve, reject) => {
+            try {
+                const webtask = require(Path.resolve(process.cwd(), args.filename)); 
+                const server = Runtime.createServer(webtask, {
+                    shortcutFavicon: true,
+                });
+                
+                return resolve(Bluebird.promisifyAll(server));
+            } catch (e) {
+                return reject(new Error(`Error starting local server: ${e.message}`));
+            }
+        });
+        
+        return promise$
+            .disposer(server => {
+                server.listening
+                    ?   server.closeAsync()
+                            .tap(() => console.log('Webtask server shut down'))
+                    :   Bluebird.resolve();
+            });
+    }
+}
+

--- a/bin/wt
+++ b/bin/wt
@@ -31,6 +31,7 @@ cli.addChild(require('./init'));
 cli.addChild(require('./create'));
 cli.addChild(require('./ls'));
 cli.addChild(require('./rm'));
+cli.addChild(require('./serve'));
 cli.addChild(require('./edit'));
 cli.addChild(require('./inspect'));
 cli.addChild(require('./update'));

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "superagent": "^1.7.2",
     "update-notifier": "^0.6.1",
     "webtask-bundle": "^2.1.1",
-    "webtask-runtime": "^1.0.0"
+    "webtask-runtime": "^1.0.1"
   },
   "bin": {
     "wt": "./bin/wt",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "structured-cli": "^1.0.4",
     "superagent": "^1.7.2",
     "update-notifier": "^0.6.1",
-    "webtask-bundle": "^2.1.1"
+    "webtask-bundle": "^2.1.1",
+    "webtask-runtime": "^1.0.0"
   },
   "bin": {
     "wt": "./bin/wt",


### PR DESCRIPTION
This PR adds a new `wt serve --port [port] <filename>` command.

The command uses `webtask-runtime` under the hood to create a local http server out of a webtask file. Note that bundling is irrelevant for this mode of operation because we are not operating on a remove machine. `require()` works as expected. `"use npm";` is a TODO.