### PR TITLE
Metadata support

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -41,6 +41,14 @@ module.exports = Cli.createCommand('create', {
                 metavar: 'KEY=VALUE',
                 type: 'string',
             },
+            'meta': {
+                action: 'append',
+                defaultValue: [],
+                description: 'Metadata describing the webtask. This is a set of string key value pairs.',
+                dest: 'meta',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
             'name': {
                 alias: 'n',
                 description: 'Name of the webtask. When specified, the resulting webtask token can be run at a special named webtask url and additional path segments are allowed (/api/run/{container}/{name}/*). This is important when using `webtask-tools` to expose an Express server as a webtask.',

--- a/bin/cron/ls.js
+++ b/bin/cron/ls.js
@@ -2,6 +2,7 @@ var Chalk = require('chalk');
 var Cli = require('structured-cli');
 var PrintCronJob = require('../../lib/printCronJob');
 var _ = require('lodash');
+var keyValList2Object = require('../../lib/keyValList2Object');
 
 
 module.exports = Cli.createCommand('ls', {
@@ -10,6 +11,17 @@ module.exports = Cli.createCommand('ls', {
         require('../_plugins/profile'),
     ],
     optionGroups: {
+        'Filtering': {
+            'meta': {
+                action: 'append',
+                defaultValue: [],
+                description: 'Metadata describing the scheduled webtask. This is a set of string key value pairs. Only scheduled webtasks with matching metadata will be returned.',
+                dest: 'meta',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+
+        },
         'Output options': {
             output: {
                 alias: 'o',
@@ -27,8 +39,10 @@ module.exports = Cli.createCommand('ls', {
 
 function handleCronLs(args) {
     var profile = args.profile;
+
+    keyValList2Object(args, 'meta');
     
-    return profile.listCronJobs({ container: args.container || profile.container })
+    return profile.listCronJobs({ container: args.container || profile.container, meta: args.meta })
         .then(onCronListing);
     
     

--- a/bin/cron/schedule.js
+++ b/bin/cron/schedule.js
@@ -119,7 +119,7 @@ function handleCronSchedule(args) {
         
         schedule = type.encode(frequencyValue);
     }
-    
+
     var createWebtask = WebtaskCreator(args, {
         onGeneration: onGeneration,
     });
@@ -133,7 +133,7 @@ function handleCronSchedule(args) {
             logger.log({ generation: build.generation, container: build.webtask.container }, 'Webtask created: %s. Scheduling cron job...', build.webtask.url);
         }
         
-        return build.webtask.createCronJob({ schedule: args.schedule })
+        return build.webtask.createCronJob({ schedule: args.schedule, meta: args.meta })
             .then(onCronScheduled, onCronError);
             
         
@@ -148,6 +148,7 @@ function handleCronSchedule(args) {
                         created_at: new Date(job.created_at).toLocaleString(),
                         run_count: job.run_count,
                         error_count: job.error_count,
+                        meta: job.meta,
                     }, 'Cron job scheduled')
                 :   PrintCronJob(job, logger);
         }

--- a/bin/ls.js
+++ b/bin/ls.js
@@ -2,6 +2,7 @@ var Chalk = require('chalk');
 var Cli = require('structured-cli');
 var PrintWebtask = require('../lib/printWebtask');
 var _ = require('lodash');
+var keyValList2Object = require('../lib/keyValList2Object');
 
 
 module.exports = Cli.createCommand('ls', {
@@ -22,6 +23,17 @@ module.exports = Cli.createCommand('ls', {
                 description: 'Limit the results to this many named webtasks',
                 defaultValue: 10,
             },
+        },
+        'Filtering': {
+            'meta': {
+                action: 'append',
+                defaultValue: [],
+                description: 'Metadata describing the webtask. This is a set of string key value pairs. Only webtasks with matching metadata will be returned.',
+                dest: 'meta',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+
         },
         'Output options': {
             'output': {
@@ -49,8 +61,10 @@ module.exports = Cli.createCommand('ls', {
 
 function handleTokenCreate(args) {
     var profile = args.profile;
+
+    keyValList2Object(args, 'meta');
     
-    return profile.listWebtasks({ offset: args.offset, limit: args.limit })
+    return profile.listWebtasks({ offset: args.offset, limit: args.limit, meta: args.meta })
         .catch(function (err) {
             if (err.statusCode >= 500) throw Cli.error.serverError(err.message);
             if (err.statusCode >= 400) throw Cli.error.badRequest(err.message);
@@ -69,6 +83,9 @@ function handleTokenCreate(args) {
                     name: json.name,
                     url: webtask.url,
                 };
+                if (webtask.meta) {
+                    record.meta = webtask.meta
+                }
                 
                 if (args.showToken) record.token = json.token;
                 

--- a/lib/createWebtask.js
+++ b/lib/createWebtask.js
@@ -13,6 +13,7 @@ function createWebtask(args, options) {
     if (!options.action) options.action = 'created';
     
     var profile = args.profile;
+
     var createWebtask = WebtaskCreator(args, {
         onGeneration: onGeneration,
         onError: onError,

--- a/lib/keyValList2Object.js
+++ b/lib/keyValList2Object.js
@@ -1,0 +1,9 @@
+var _ = require('lodash');
+
+module.exports = function (args, field) {
+    args[field] = _.reduce(args[field], function (acc, entry) {
+        var parts = entry.split('=');
+
+        return _.set(acc, parts.shift(), parts.join('='));
+    }, {});
+};

--- a/lib/printCronJob.js
+++ b/lib/printCronJob.js
@@ -31,4 +31,10 @@ function printCronJob(job) {
     if (job.expires_at) {
         console.log(Chalk.blue(Pad('Expires:', WIDTH)), new Date(job.expires_at).toLocaleString());
     }
+
+    if (job.meta) {
+        for (var m in job.meta) {
+            console.log(Chalk.blue(Pad('Meta.' + m + ':', WIDTH)), job.meta[m]);
+        }
+    }
 }

--- a/lib/printWebtask.js
+++ b/lib/printWebtask.js
@@ -20,6 +20,12 @@ function printWebtask(webtask, options) {
     if (options.token) {
         console.log(Chalk.blue(Pad('Token:', WIDTH)), webtask.token);
     }
+
+    if (webtask.meta) {
+        for (var m in webtask.meta) {
+            console.log(Chalk.blue(Pad('Meta.' + m + ':', WIDTH)), webtask.meta[m]);
+        }
+    }
     
     if (options.details) {
         try {

--- a/lib/validateCreateArgs.js
+++ b/lib/validateCreateArgs.js
@@ -1,6 +1,7 @@
 var Cli = require('structured-cli');
 var Path = require('path');
 var _ = require('lodash');
+var keyValList2Object = require('./keyValList2Object');
 
 var ip_regex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
 var dns_regex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
@@ -67,16 +68,9 @@ function validateCreateArgs(args) {
             .digest('hex');
     }
 
-    parseKeyValList(args, 'secrets');
-    parseKeyValList(args, 'params');
+    keyValList2Object(args, 'secrets');
+    keyValList2Object(args, 'params');
+    keyValList2Object(args, 'meta');
 
     return args;
-
-    function parseKeyValList(args, field) {
-        args[field] = _.reduce(args[field], function (acc, entry) {
-            var parts = entry.split('=');
-
-            return _.set(acc, parts.shift(), parts.join('='));
-        }, {});
-    }
 }

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -46,6 +46,7 @@ function createWebtaskCreator(args, options) {
                     parse: args.parse,
                     secrets: args.secrets,
                     params: args.params,
+                    meta: args.meta,
                     host: args.host
                 });
             })
@@ -112,6 +113,7 @@ function createWebtaskCreator(args, options) {
                 parse: args.parse,
                 secrets: args.secrets,
                 params: args.params,
+                meta: args.meta,
                 host: args.host
             });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "open": "0.0.5",
     "pad": "^1.0.0",
     "promptly": "^0.2.1",
-    "sandboxjs": "^2.4.0",
+    "sandboxjs": "^2.5.0",
     "structured-cli": "^1.0.4",
     "superagent": "^1.7.2",
     "update-notifier": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",


### PR DESCRIPTION
**NOTE** This PR requires that https://github.com/auth0/sandboxjs/pull/6/files is published to NPM first.

This adds support for `--meta` parameters to the following commands: 

```
wt create ... --meta foo=bar --meta baz=12 ...
wt ls --meta foo=bar --meta baz=12 ...
wt cron schedule ... --meta foo=bar --meta baz=12 ...
wt cron ls --meta foo=bar --meta baz=12 ...
```

