### PR TITLE
Adding local debugging

### DIFF
--- a/bin/debug.js
+++ b/bin/debug.js
@@ -20,7 +20,6 @@ config.optionGroups.ExecutionOptions =
         }
     };
 
-
 module.exports = Cli.createCommand('debug', config);
 
 function handleDebug(args) {

--- a/bin/debug.js
+++ b/bin/debug.js
@@ -4,7 +4,7 @@ const Bluebird = require('bluebird');
 const Cli = require('structured-cli');
 const spawn = require('child_process').spawn;
 const _ = require('lodash');
-const config = require('./serveCommon')
+const config = require('./serveCommon')();
 var newArgs = null;;
 
 config.description = "Debug a webtask";

--- a/bin/debug.js
+++ b/bin/debug.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const config = require('./serveCommon')
 var newArgs = null;;
 
-config.description = "Run Run a webtask as a local http server";
+config.description = "Debug a webtask";
 config.handler = handleDebug;
 config.optionGroups.ExecutionOptions =
     {

--- a/bin/debug.js
+++ b/bin/debug.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Bluebird = require('bluebird');
+const Cli = require('structured-cli');
+const spawn = require('child_process').spawn;
+const _ = require('lodash');
+const config = require('./serveCommon')
+var newArgs = null;;
+
+config.description = "Run Run a webtask as a local http server";
+config.handler = handleDebug;
+config.optionGroups.ExecutionOptions =
+    {
+        'debugger': {
+            alias: 'd',
+            description: 'Debugger to use. "devtool" requires installing the devtool cli (npm install devtool -g)',
+            choices: ['devtool', 'node'],
+            dest: 'debugger',
+            defaultValue: 'node'
+        }
+    };
+
+
+module.exports = Cli.createCommand('debug', config);
+
+function handleDebug(args) {
+    newArgs = [process.argv[1], 'serve']
+    _.each(process.argv.slice(3), (value)=> {
+        var arg = value.toLowerCase();
+        if (!(arg === 'debug' || (arg.startsWith('--debugger=') || arg.startsWith('-d')))) {
+            newArgs.push(arg);
+        }
+    });
+    if (args.debugger === 'node') {
+        return new Bluebird(debugNode);
+    }
+    else if (args.debugger === 'devtool') {
+        return new Bluebird(debugDevtool);
+    }
+}
+
+function debugNode(resolve, reject) {
+    newArgs = ['--debug'].concat(newArgs); 
+    spawnProcess(process.execPath, newArgs, resolve);
+}
+
+function debugDevtool(resolve, reject) {
+    spawnProcess('devtool', newArgs, resolve);
+}
+
+function spawnProcess(launcher, args, resolve) {
+    var node = spawn(launcher, args);
+    
+    node.stdout.on('data', (data) => {
+        console.log(`${data}`);
+    });
+
+    node.stderr.on('data', (data) => {
+        console.error(`${data}`);
+    });
+
+    node.on('close', (code) => {
+        resolve();
+    });
+}

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,97 +1,23 @@
 'use strict';
 
-
 const Bluebird = require('bluebird');
 const Chalk = require('chalk');
 const Cli = require('structured-cli');
 const Path = require('path');
 const Runtime = require('webtask-runtime');
-const spawn = require('child_process').spawn;
-const process = require('process');
 const _ = require('lodash');
+const config = require('./serveCommon')
 
-var i = null;
+config.description = "Run a webtask as a local http server";
+config.handler = handleWebtaskServe;
 
-module.exports = Cli.createCommand('serve', {
-    description: 'Run a webtask as a local http server',
-    optionGroups: {
-        'Server options': {
-            port: {
-                alias: 'p',
-                description: 'Port on which the webtask server will listen',
-                type: 'int',
-                defaultValue: 8080,
-            },
-            'hostname': {
-                description: 'The hostname for the http listener',
-                type: 'string',
-                defaultValue: '0.0.0.0',
-            },
-        },
-        'Execution options': {
-            'debugtask': {
-                alias: 'd',
-                description: 'Debug your task locally. "devtool" requires installing the devtool cli (npm install devtool -g)',
-                choices: ['devtool', 'node'],
-                dest: 'debugtask'
-            }
-        },
-        'Webtask creation': {
-            'secret': {
-                action: 'append',
-                alias: 's',
-                defaultValue: [],
-                description: 'Secret(s) exposed to your code as `secrets` on the webtask context object. These secrets will be encrypted and stored in a webtask token in such a way that only the webtask server is able to decrypt the secrets so that they may be exposed to your running webtask code.',
-                dest: 'secrets',
-                metavar: 'KEY=VALUE',
-                type: 'string',
-            },
-            'param': {
-                action: 'append',
-                defaultValue: [],
-                description: 'Param(s) exposed to your code as `params` on the webtask context object. The properties will be signed and protected from interference but not encrypted.',
-                dest: 'params',
-                metavar: 'KEY=VALUE',
-                type: 'string',
-            },
-            'no-merge': {
-                action: 'storeFalse',
-                defaultValue: true,
-                description: 'Disable automatic merging of the parsed body and secrets into the `data` field of the webtask context object. The parsed body (if available) will be on the `body` field and secrets on the `secrets` field.',
-                dest: 'mergeBody',
-            },
-            'no-parse': {
-                action: 'storeFalse',
-                defaultValue: true,
-                description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
-                dest: 'parseBody',
-            },
-            'storage-file': {
-                description: 'Provide a file that will be used to initialize and persist webtask storage data',
-                dest: 'storageFile',
-            },
-        },
-    },
-    params: {
-        'filename': {
-            description: 'The path to the webtask\'s source code',
-            type: 'string',
-            required: true,
-        },
-    },
-    handler: handleWebtaskServe,
-});
-
+module.exports = Cli.createCommand('serve', config);
 
 // Command handler
 
 function handleWebtaskServe(args) {
     parseKeyValList(args, 'secrets');
     parseKeyValList(args, 'params');
-
-    if (args.debugtask != undefined) {
-        return handleDebug();
-    } 
     
     return Bluebird.using(createServer(), server => {
         return server.listenAsync(args.port, args.hostname)
@@ -104,58 +30,8 @@ function handleWebtaskServe(args) {
             .then(server => {
                 console.log('Automatically shutting down your webtask server after 30m');
             });
-    })
-        .timeout(1000 * 60 * 30);
+    }).timeout(1000 * 60 * 30);
     
-    
-    function handleDebug() {
-        i = process.argv.findIndex((item) => {return item.startsWith("--debugtask")});
-        i = i > -1 ? i : process.argv.findIndex((i) => {return i.startsWith("-d=")});
-
-        if (args.debugtask == "node") {
-            return new Bluebird(debugNode);
-        }
-        else if (args.debugtask == "devtool") {
-            return new Bluebird(debugDevtool);
-        }
-    }
-    
-    function debugNode(resolve, reject) {
-        var newArgs = ['--debug'].concat(process.argv.slice(1, i)); 
-
-        if (process.argv.length >= i-1) 
-        {
-            var newArgs = newArgs.concat(process.argv.slice(i+1, process.argv.length));
-        }
-        spawnProcess(process.execPath, newArgs, resolve);
-    }
-
-    function debugDevtool(resolve, reject) {
-        var newArgs = process.argv.slice(1, i); 
-
-        if (process.argv.length >= i-1) 
-        {
-            var newArgs = newArgs.concat(process.argv.slice(i+1, process.argv.length));
-        }
-        spawnProcess('devtool', newArgs, resolve);
-    }
-
-    function spawnProcess(launcher, args, resolve) {
-        var node = spawn(launcher, args);
-        
-        node.stdout.on('data', (data) => {
-            console.log(`${data}`);
-        });
-
-        node.stderr.on('data', (data) => {
-            console.error(`${data}`);
-        });
-
-        node.on('close', (code) => {
-            resolve();
-        });
-    }
-
     function createServer() {
         const promise$ = new Bluebird((resolve, reject) => {
             try {
@@ -183,7 +59,6 @@ function handleWebtaskServe(args) {
                     :   Bluebird.resolve();
             });
     }
-
 
     function parseKeyValList(args, field) {
         args[field] = _.reduce(args[field], function (acc, entry) {

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -66,7 +66,6 @@ function handleWebtaskServe(args) {
 
             return _.set(acc, parts.shift(), parts.join('='));
         }, {});
-    }
-    
+    }    
 }
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -6,7 +6,7 @@ const Cli = require('structured-cli');
 const Path = require('path');
 const Runtime = require('webtask-runtime');
 const _ = require('lodash');
-const config = require('./serveCommon')
+const config = require('./serveCommon')();
 
 config.description = "Run a webtask as a local http server";
 config.handler = handleWebtaskServe;

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -6,8 +6,11 @@ const Chalk = require('chalk');
 const Cli = require('structured-cli');
 const Path = require('path');
 const Runtime = require('webtask-runtime');
+const spawn = require('child_process').spawn;
 const _ = require('lodash');
+const process = require('process');
 
+var i = null;
 
 module.exports = Cli.createCommand('serve', {
     description: 'Run a webtask as a local http server',
@@ -24,6 +27,14 @@ module.exports = Cli.createCommand('serve', {
                 type: 'string',
                 defaultValue: '0.0.0.0',
             },
+        },
+        'Execution options': {
+            'debugtask': {
+                alias: 'd',
+                description: 'Debug your task locally. "devtool" requires installing the devtool cli (npm install devtool -g)',
+                choices: ['devtool', 'node'],
+                dest: 'debugtask'
+            }
         },
         'Webtask creation': {
             'secret': {
@@ -78,6 +89,10 @@ function handleWebtaskServe(args) {
     parseKeyValList(args, 'secrets');
     parseKeyValList(args, 'params');
 
+    if (args.debugtask != undefined) {
+        return handleDebug();
+    } 
+    
     return Bluebird.using(createServer(), server => {
         return server.listenAsync(args.port, args.hostname)
             .tap(() => {
@@ -92,6 +107,54 @@ function handleWebtaskServe(args) {
     })
         .timeout(1000 * 60 * 30);
     
+    
+    function handleDebug() {
+        i = process.argv.findIndex((item) => {return item.startsWith("--debugtask")});
+        i = i > -1 ? i : process.argv.findIndex((i) => {return i.startsWith("-d=")});
+
+        if (args.debugtask == "node") {
+            return new Bluebird(debugNode);
+        }
+        else if (args.debugtask == "devtool") {
+            return new Bluebird(debugDevtool);
+        }
+    }
+    
+    function debugNode(resolve, reject) {
+        var newArgs = ['--debug'].concat(process.argv.slice(1, i)); 
+
+        if (process.argv.length >= i-1) 
+        {
+            var newArgs = newArgs.concat(process.argv.slice(i+1, process.argv.length));
+        }
+        spawnProcess(process.execPath, newArgs, resolve);
+    }
+
+    function debugDevtool(resolve, reject) {
+        var newArgs = process.argv.slice(1, i); 
+
+        if (process.argv.length >= i-1) 
+        {
+            var newArgs = newArgs.concat(process.argv.slice(i+1, process.argv.length));
+        }
+        spawnProcess('devtool', newArgs, resolve);
+    }
+
+    function spawnProcess(launcher, args, resolve) {
+        var node = spawn(launcher, args);
+        
+        node.stdout.on('data', (data) => {
+            console.log(`${data}`);
+        });
+
+        node.stderr.on('data', (data) => {
+            console.error(`${data}`);
+        });
+
+        node.on('close', (code) => {
+            resolve();
+        });
+    }
 
     function createServer() {
         const promise$ = new Bluebird((resolve, reject) => {

--- a/bin/serveCommon.js
+++ b/bin/serveCommon.js
@@ -1,0 +1,60 @@
+module.exports = {
+    description: 'Run a webtask as a local http server',
+    optionGroups: {
+        'Server options': {
+            port: {
+                alias: 'p',
+                description: 'Port on which the webtask server will listen',
+                type: 'int',
+                defaultValue: 8080,
+            },
+            'hostname': {
+                description: 'The hostname for the http listener',
+                type: 'string',
+                defaultValue: '0.0.0.0',
+            },
+        },
+        'Webtask creation': {
+            'secret': {
+                action: 'append',
+                alias: 's',
+                defaultValue: [],
+                description: 'Secret(s) exposed to your code as `secrets` on the webtask context object. These secrets will be encrypted and stored in a webtask token in such a way that only the webtask server is able to decrypt the secrets so that they may be exposed to your running webtask code.',
+                dest: 'secrets',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+            'param': {
+                action: 'append',
+                defaultValue: [],
+                description: 'Param(s) exposed to your code as `params` on the webtask context object. The properties will be signed and protected from interference but not encrypted.',
+                dest: 'params',
+                metavar: 'KEY=VALUE',
+                type: 'string',
+            },
+            'no-merge': {
+                action: 'storeFalse',
+                defaultValue: true,
+                description: 'Disable automatic merging of the parsed body and secrets into the `data` field of the webtask context object. The parsed body (if available) will be on the `body` field and secrets on the `secrets` field.',
+                dest: 'mergeBody',
+            },
+            'no-parse': {
+                action: 'storeFalse',
+                defaultValue: true,
+                description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
+                dest: 'parseBody',
+            },
+            'storage-file': {
+                description: 'Provide a file that will be used to initialize and persist webtask storage data',
+                dest: 'storageFile',
+            },
+        },
+    },
+    params: {
+        'filename': {
+            description: 'The path to the webtask\'s source code',
+            type: 'string',
+            required: true,
+        },
+    }
+}

--- a/bin/serveCommon.js
+++ b/bin/serveCommon.js
@@ -1,59 +1,61 @@
-module.exports = {
-    optionGroups: {
-        'Server options': {
-            port: {
-                alias: 'p',
-                description: 'Port on which the webtask server will listen',
-                type: 'int',
-                defaultValue: 8080,
+module.exports = () => {
+    return {
+        optionGroups: {
+            'Server options': {
+                port: {
+                    alias: 'p',
+                    description: 'Port on which the webtask server will listen',
+                    type: 'int',
+                    defaultValue: 8080,
+                },
+                'hostname': {
+                    description: 'The hostname for the http listener',
+                    type: 'string',
+                    defaultValue: '0.0.0.0',
+                },
             },
-            'hostname': {
-                description: 'The hostname for the http listener',
-                type: 'string',
-                defaultValue: '0.0.0.0',
+            'Webtask creation': {
+                'secret': {
+                    action: 'append',
+                    alias: 's',
+                    defaultValue: [],
+                    description: 'Secret(s) exposed to your code as `secrets` on the webtask context object. These secrets will be encrypted and stored in a webtask token in such a way that only the webtask server is able to decrypt the secrets so that they may be exposed to your running webtask code.',
+                    dest: 'secrets',
+                    metavar: 'KEY=VALUE',
+                    type: 'string',
+                },
+                'param': {
+                    action: 'append',
+                    defaultValue: [],
+                    description: 'Param(s) exposed to your code as `params` on the webtask context object. The properties will be signed and protected from interference but not encrypted.',
+                    dest: 'params',
+                    metavar: 'KEY=VALUE',
+                    type: 'string',
+                },
+                'no-merge': {
+                    action: 'storeFalse',
+                    defaultValue: true,
+                    description: 'Disable automatic merging of the parsed body and secrets into the `data` field of the webtask context object. The parsed body (if available) will be on the `body` field and secrets on the `secrets` field.',
+                    dest: 'mergeBody',
+                },
+                'no-parse': {
+                    action: 'storeFalse',
+                    defaultValue: true,
+                    description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
+                    dest: 'parseBody',
+                },
+                'storage-file': {
+                    description: 'Provide a file that will be used to initialize and persist webtask storage data',
+                    dest: 'storageFile',
+                },
             },
         },
-        'Webtask creation': {
-            'secret': {
-                action: 'append',
-                alias: 's',
-                defaultValue: [],
-                description: 'Secret(s) exposed to your code as `secrets` on the webtask context object. These secrets will be encrypted and stored in a webtask token in such a way that only the webtask server is able to decrypt the secrets so that they may be exposed to your running webtask code.',
-                dest: 'secrets',
-                metavar: 'KEY=VALUE',
+        params: {
+            'filename': {
+                description: 'The path to the webtask\'s source code',
                 type: 'string',
+                required: true,
             },
-            'param': {
-                action: 'append',
-                defaultValue: [],
-                description: 'Param(s) exposed to your code as `params` on the webtask context object. The properties will be signed and protected from interference but not encrypted.',
-                dest: 'params',
-                metavar: 'KEY=VALUE',
-                type: 'string',
-            },
-            'no-merge': {
-                action: 'storeFalse',
-                defaultValue: true,
-                description: 'Disable automatic merging of the parsed body and secrets into the `data` field of the webtask context object. The parsed body (if available) will be on the `body` field and secrets on the `secrets` field.',
-                dest: 'mergeBody',
-            },
-            'no-parse': {
-                action: 'storeFalse',
-                defaultValue: true,
-                description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
-                dest: 'parseBody',
-            },
-            'storage-file': {
-                description: 'Provide a file that will be used to initialize and persist webtask storage data',
-                dest: 'storageFile',
-            },
-        },
-    },
-    params: {
-        'filename': {
-            description: 'The path to the webtask\'s source code',
-            type: 'string',
-            required: true,
-        },
+        }
     }
 }

--- a/bin/serveCommon.js
+++ b/bin/serveCommon.js
@@ -1,5 +1,4 @@
 module.exports = {
-    description: 'Run a webtask as a local http server',
     optionGroups: {
         'Server options': {
             port: {

--- a/bin/wt
+++ b/bin/wt
@@ -33,6 +33,7 @@ cli.addChild(require('./ls'));
 cli.addChild(require('./mv'));
 cli.addChild(require('./rm'));
 cli.addChild(require('./serve'));
+cli.addChild(require('./debug'));
 cli.addChild(require('./edit'));
 cli.addChild(require('./inspect'));
 cli.addChild(require('./update'));


### PR DESCRIPTION
This PR introduces local debugging using [devtool] (https://github.com/Jam3/devtool) or using IDE's like VSCode which support node debugging. In it's current form, it requires the task to be local and all the required modules to be present in the local `node_modules` folder or a parent folder.

To enable the debugging feature the `debug` command is introduced.

* `wt debug task.js` - launches task.js using the node debugger. This allows debugging using a tool such as VS Code which supports connecting to the node debugger port.
* `wt debug task.js --debugger=devtool` - debugs task.us using the Electron based Devtool. The debugger will pop up. Devtool must be installed for this to work.




