### PR TITLE
Added `wt browse <name>` command

### DIFF
--- a/bin/browse.js
+++ b/bin/browse.js
@@ -1,0 +1,32 @@
+var Chalk = require('chalk');
+var Cli = require('structured-cli');
+var Open = require('open');
+
+
+module.exports = Cli.createCommand('browse', {
+    description: 'Browse this webtask in your browser (HTTP GET)',
+    plugins: [
+        require('./_plugins/profile'),
+    ],
+    params: {
+        'name': {
+            description: 'The named webtask you want to browse',
+            type: 'string',
+            required: true
+        },
+    },
+    handler: handleBrowse,
+});
+
+
+// Command handler
+
+function handleBrowse(args) {
+    var profile = args.profile;
+    var wtName  = args.name ? args.name + '/' : '';
+    var url     = profile.url + '/api/run/' + profile.container + '/' + wtName;
+
+    console.log('Browsing ' + Chalk.underline(args.name) + ' in your browser...');
+
+    Open(url);
+}

--- a/bin/wt
+++ b/bin/wt
@@ -35,6 +35,7 @@ cli.addChild(require('./rm'));
 cli.addChild(require('./serve'));
 cli.addChild(require('./debug'));
 cli.addChild(require('./edit'));
+cli.addChild(require('./browse'));
 cli.addChild(require('./inspect'));
 cli.addChild(require('./update'));
 cli.addChild(require('./profile'));


### PR DESCRIPTION
Fixes #80.

Followed the instruction provided by @ggoodman in [#80 (comment)](https://github.com/auth0/wt-cli/issues/80#issuecomment-246416558).

**How to test**

1. Install `wt-cli` from this pull request
   ```sh
   # using npm
   $ npm install -g auth0/wt-cli#pull/91/head

   # using yarn
   $ yarn global add auth0/wt-cli#91/head
   ```   
   *You might need to clear `npm`/`yarn` cache before installing*   


2. Run `wt browse <name>` in your shell
3. It should open your preferred browser and fire a get request to the Webtask.

Would love to hear your feedback on this, thanks 😄 