### PR TITLE
Change regex for verifying email addresses

### DIFF
--- a/lib/userVerifier.js
+++ b/lib/userVerifier.js
@@ -80,5 +80,5 @@ UserVerifier.isPhone = function (value) {
 };
     
 UserVerifier.isEmail = function (value) {
-    return !!value.match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i);
+    return !!value.match(/[^@]+@[^@]+/i);
 };


### PR DESCRIPTION
Fix validation of emails registered on top-level domains with more than 4 letters, like `email` (see list of possible top-level domains https://www.icann.org/resources/pages/tlds-2012-02-25-en, and this is only en top-level domains). 
As it is hard to maintain regex which will work for all possible email variations, the easiest way to just accept most of them (just to validate, that email has only one `@`, however I am not really sure that this is a good restriction), and if server will fail to deliver email - nothing bad can happen in that case.