### PR TITLE
Allow specifiying secrets using .env

### DIFF
--- a/lib/loadDotEnv.js
+++ b/lib/loadDotEnv.js
@@ -1,0 +1,13 @@
+var fs = require('fs');
+var dotenv = require('dotenv');
+
+module.exports = function () {
+    var path = '.env';
+    var encoding = 'utf8';
+
+    try {
+        return dotenv.parse(fs.readFileSync(path, { encoding: encoding }));
+    } catch (error) {
+        return {};
+    }
+};

--- a/lib/validateCreateArgs.js
+++ b/lib/validateCreateArgs.js
@@ -2,6 +2,7 @@ var Cli = require('structured-cli');
 var Path = require('path');
 var _ = require('lodash');
 var keyValList2Object = require('./keyValList2Object');
+var loadDotEnv = require('./loadDotEnv');
 
 var ip_regex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/;
 var dns_regex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
@@ -69,6 +70,8 @@ function validateCreateArgs(args) {
     }
 
     keyValList2Object(args, 'secrets');
+    args.secrets = _.merge(loadDotEnv(), args.secrets);
+
     keyValList2Object(args, 'params');
     keyValList2Object(args, 'meta');
 


### PR DESCRIPTION
Closes #77 

It loads the contents from `.env` as secrets. If there's a secret that is also specified using CLI, it will use the value instead.

For example:

If we have a `.env` file like this:

```bash
ACCESS_TOKEN=XOBf-2uB4hjDBXrBpS5Dj62Oyava-6CgSjEzeqNOtTM
```

When a user run:

```bash
$ wt create sample.js --secret ACCESS_TOKEN=SOMETHING_ELSE
```

The final value of `ACCESS_TOKEN` goes to the webtask server will be `SOMETHING_ELSE`.

**How to test**

1. Install `wt-cli` from this pull request
   ```sh
   # using npm
   $ npm install -g auth0/wt-cli#pull/93/head

   # using yarn
   $ yarn global add auth0/wt-cli#93/head
   ```   
   *You might need to clear `npm`/`yarn` cache before installing*   

2. Create a `.env` file and put your secrets 🔐  in
3. Run `wt create <task-to-be-created-or-updated>`
4. Test your webtask and check the secrets are properly set

Would love to hear your feedback on this, thanks 😄 