### PR TITLE
support arity-based default for body parsing

### DIFF
--- a/bin/create.js
+++ b/bin/create.js
@@ -66,10 +66,13 @@ module.exports = Cli.createCommand('create', {
                 dest: 'merge',
             },
             'no-parse': {
-                action: 'storeFalse',
-                defaultValue: true,
-                description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
-                dest: 'parse',
+                description: 'Deprecated and ignored.',
+                type: 'boolean'
+            },
+            'parse-body': {
+                description: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the reqeust body and store it in ctx.body.',
+                type: 'boolean',
+                dest: 'parseBody'
             },
             'bundle': {
                 alias: 'b',
@@ -115,8 +118,8 @@ module.exports = Cli.createCommand('create', {
         + '2. Create a webtask with one secret:' + '\n'
         + Chalk.bold('  $ wt create --secret name=webtask ./sample-webtasks/html-response.js') + '\n'
         + '\n'
-        + '3. Create a webtask that is bundled before deploying. Note that --no-parse is needed since we are using webtask-tools with Express and body-parser:' + '\n'
-        + Chalk.bold('  $ wt create --secret name=webtask --bundle --no-parse ./sample-webtasks/bundled-webtask.js') + '\n'
+        + '3. Create a webtask that is bundled before deploying:' + '\n'
+        + Chalk.bold('  $ wt create --secret name=webtask --bundle ./sample-webtasks/bundled-webtask.js') + '\n'
     ,
     handler: handleCreate,
 });

--- a/bin/create.js
+++ b/bin/create.js
@@ -70,7 +70,7 @@ module.exports = Cli.createCommand('create', {
                 type: 'boolean'
             },
             'parse-body': {
-                description: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the reqeust body and store it in ctx.body.',
+                description: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the request body and store it in ctx.body.',
                 type: 'boolean',
                 dest: 'parseBody'
             },

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -37,7 +37,7 @@ function handleWebtaskServe(args) {
             try {
                 const webtask = require(Path.resolve(process.cwd(), args.filename)); 
                 const server = Runtime.createServer(webtask, {
-                    parseBody: args.parseBody,
+                    parseBody: args.parseBody ? Runtime.PARSE_ALWAYS : undefined,
                     mergeBody: args.mergeBody,
                     secrets: args.secrets,
                     params: args.params,

--- a/bin/serveCommon.js
+++ b/bin/serveCommon.js
@@ -39,10 +39,12 @@ module.exports = () => {
                     dest: 'mergeBody',
                 },
                 'no-parse': {
-                    action: 'storeFalse',
-                    defaultValue: true,
-                    description: 'Disable automatic parsing of the incoming request body. Important: when using webtask-tools with Express and the body-parser middleware, automatic body parsing must be disabled.',
-                    dest: 'parseBody',
+                    description: 'Deprecated and ignored.'
+                },
+                'parse-body': {
+                    descrption: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the reqeust body and store it in ctx.body.',
+                    type: 'boolean',
+                    dest: 'parseBody'
                 },
                 'storage-file': {
                     description: 'Provide a file that will be used to initialize and persist webtask storage data',

--- a/bin/serveCommon.js
+++ b/bin/serveCommon.js
@@ -42,7 +42,7 @@ module.exports = () => {
                     description: 'Deprecated and ignored.'
                 },
                 'parse-body': {
-                    descrption: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the reqeust body and store it in ctx.body.',
+                    descrption: 'Automatically parse JSON and application/x-www-form-urlencoded request bodies. Use this with (ctx, req, res) webtask signatures if you want webtask runtime to parse the request body and store it in ctx.body.',
                     type: 'boolean',
                     dest: 'parseBody'
                 },

--- a/bin/token/create.js
+++ b/bin/token/create.js
@@ -42,7 +42,7 @@ var RAW_CLAIMS = {
         type: 'boolean',
     },
     pb: {
-        type: 'boolean',
+        type: 'int',
     },
     dr: {
         type: 'boolean',
@@ -131,10 +131,7 @@ function handleTokenCreate(args) {
     
     if (claims.mb) claims.mb = 1;
     else delete claims.mb;
-    
-    if (claims.pb) claims.pb = 1;
-    else delete claims.pb;
-    
+        
     if (args.claims) {
         try {
             claims = _.defaultsDeep(claims, JSON.parse(args.claims));

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -43,7 +43,7 @@ function createWebtaskCreator(args, options) {
                 return profile.create(codeOrUrl, {
                     name: args.name,
                     merge: args.merge,
-                    parse: args.parse,
+                    parse: (args.parseBody || args.parse) !== undefined ? +(args.parseBody || args.parse) : undefined,
                     secrets: args.secrets,
                     params: args.params,
                     meta: args.meta,
@@ -110,7 +110,7 @@ function createWebtaskCreator(args, options) {
             var webtask$ = profile.create(build.code, {
                 name: args.name,
                 merge: args.merge,
-                parse: args.parse,
+                parse: (args.parseBody || args.parse) !== undefined ? +(args.parseBody || args.parse) : undefined,
                 secrets: args.secrets,
                 params: args.params,
                 meta: args.meta,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",
@@ -44,13 +44,13 @@
     "open": "0.0.5",
     "pad": "^1.0.0",
     "promptly": "^0.2.1",
-    "sandboxjs": "^3.1.0",
+    "sandboxjs": "^3.2.0",
     "structured-cli": "^1.0.5",
     "superagent": "^1.7.2",
     "through2": "^2.0.1",
     "update-notifier": "^0.6.1",
     "webtask-bundle": "^2.3.0",
-    "webtask-runtime": "^1.2.0",
+    "webtask-runtime": "^1.4.0",
     "wreck": "^10.0.0"
   },
   "bin": {


### PR DESCRIPTION
This requires that https://github.com/auth0/webtask-ops/pull/79 is rolled out to prod.

Key differences in the wt-cli:

* the `--no-parse` options are gone from everywhere (deprecated)  
* on create, a `--parse-body` was introduced instead that *forces* parsing of the JSON/urlencoded bodies instead of relaying on the arity-based default behavior. This is useful for (ctx, req, res) webtasks that sill want their body parsed automatically (e.g. non-Express). 