### PR TITLE
displaying url when using `wt edit`

### DIFF
--- a/bin/edit.js
+++ b/bin/edit.js
@@ -31,6 +31,6 @@ function handleEdit(args) {
     } else {
         console.log('Opening Webtask Editor');
     }
-    
+    console.log('If nothing happens, open this url: ' + url);
     Open(url);
 }


### PR DESCRIPTION
Sometimes (https://github.com/auth0/wt-cli/issues/81), the `open` command does nothing and we can't edit the webtask. This ensures that we can copy and paste the url and still edit the webtask.