### PR TITLE
Remove dependency on bunyan (and DTrace) for logs

### DIFF
--- a/lib/logs.js
+++ b/lib/logs.js
@@ -1,5 +1,9 @@
-var Bunyan = require('bunyan');
-var PrettyStream = require('bunyan-prettystream');
+'use strict';
+
+const Os = require('os');
+const PrettyStream = require('bunyan-prettystream');
+const Util = require('util');
+const _ = require('lodash');
 
 
 exports.createLogStream = createLogStream;
@@ -7,55 +11,150 @@ exports.createLogStream = createLogStream;
 
 function createLogStream(profile, options) {
     if (!options) options = {};
-    
+
     var logStream = profile.createLogStream({ json: true });
     var logger = options.raw
         ?   console
         :   createBunyanLogger();
-    
+
     logStream.once('open', function () {
         logger.info({ container: options.container || profile.container },
             'connected to streaming logs');
     });
-    
+
     logStream.once('close', function () {
         logger.error('Connection closed');
     });
-    
+
     logStream.once('error', function (err) {
         console.dir(err.stack);
         logger.error(err.message);
     });
 
-    // setTimeout(function () {
-    //     logger.warn('reached maximum connection time of 30min, '
-    //         +'disconnecting');
-        
-    //     process.exit(1);
-    // }, 30 * 60 * 1000).unref();
-    
     logStream.on('data', function (data) {
         options.verbose
             ?   logger.info(data, data.msg)
             :   logger.info(data.msg);
     });
-    
+
     return logger;
 }
 
 
 function createBunyanLogger() {
     var prettyStdOut = new PrettyStream({ mode: 'short' });
-    var logger = Bunyan.createLogger({
-          name: 'wt',
-          streams: [{
-              level: 'debug',
-              type: 'raw',
-              stream: prettyStdOut
-          }]
-    });    
+    // var logger = Bunyan.createLogger({
+    //       name: 'wt',
+    //       streams: [{
+    //           level: 'debug',
+    //           type: 'raw',
+    //           stream: prettyStdOut
+    //       }]
+    // });
+
+    prettyStdOut.trace = mkLogEmitter(10);
+    prettyStdOut.debug = mkLogEmitter(20);
+    prettyStdOut.info = mkLogEmitter(30);
+    prettyStdOut.warn = mkLogEmitter(40);
+    prettyStdOut.error = mkLogEmitter(50);
+    prettyStdOut.fatal = mkLogEmitter(60);
 
     prettyStdOut.pipe(process.stdout);
-    
-    return logger;
+
+    return prettyStdOut;
+}
+
+function mkLogEmitter(minLevel) {
+    return function() {
+        if (arguments.length === 0) {   // `log.<level>()`
+            return (this._level <= minLevel);
+        }
+
+        const msgArgs = new Array(arguments.length);
+        for (let i = 0; i < msgArgs.length; ++i) {
+            msgArgs[i] = arguments[i];
+        }
+
+        const rec = mkRecord(minLevel, msgArgs);
+
+        this.write(rec);
+    };
+}
+
+function mkRecord(level, args) {
+    var fields, msgArgs;
+    if (args[0] instanceof Error) {
+        // `log.<level>(err, ...)`
+        fields = {
+            // Use this Logger's err serializer, if defined.
+            err: serializeError(args[0]),
+        };
+        if (args.length === 1) {
+            msgArgs = [fields.err.message];
+        } else {
+            msgArgs = args.slice(1);
+        }
+    } else if (typeof (args[0]) !== 'object' || Array.isArray(args[0])) {
+        // `log.<level>(msg, ...)`
+        fields = null;
+        msgArgs = args.slice();
+    } else if (Buffer.isBuffer(args[0])) {  // `log.<level>(buf, ...)`
+        // Almost certainly an error, show `inspect(buf)`. See bunyan
+        // issue #35.
+        fields = null;
+        msgArgs = args.slice();
+        msgArgs[0] = Util.inspect(msgArgs[0]);
+    } else {  // `log.<level>(fields, msg, ...)`
+        fields = args[0];
+        if (fields && args.length === 1 && fields.err &&
+            fields.err instanceof Error)
+        {
+            msgArgs = [fields.err.message];
+        } else {
+            msgArgs = args.slice(1);
+        }
+    }
+
+    // Build up the record object.
+    var rec = {
+        level,
+        hostname: Os.hostname(),
+        name: 'wt',
+        pid: process.pid,
+    };
+    var recFields = (fields ? _.clone(fields) : null);
+    if (recFields) {
+        Object.keys(recFields).forEach(function (k) {
+            rec[k] = recFields[k];
+        });
+    }
+    rec.msg = Util.format.apply(Util, msgArgs);
+    if (!rec.time) {
+        rec.time = (new Date());
+    }
+
+    return rec;
+}
+
+function serializeError(error) {
+    if (!error || !error.stack)
+        return error;
+    return Object.create({
+        message: error.message,
+        name: error.name,
+        stack: getFullErrorStack(error),
+        code: error.code,
+        signal: error.signal
+    }, null);
+}
+
+function getFullErrorStack(ex) {
+    var ret = ex.stack || ex.toString();
+    if (ex.cause && typeof (ex.cause) === 'function') {
+        var cex = ex.cause();
+        if (cex) {
+            ret += '\nCaused by: ' + getFullErrorStack(cex);
+        }
+    }
+    return (ret);
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "through2": "^2.0.1",
     "update-notifier": "^0.6.1",
     "webtask-bundle": "^2.3.0",
-    "webtask-runtime": "^1.5.0",
+    "webtask-runtime": "^1.6.0",
     "wreck": "^10.0.0"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "auth0-hooks-templates": "^1.2.0",
     "bluebird": "^2.10.2",
     "boom": "^2.8.0",
-    "bunyan": "^1.5.1",
     "bunyan-prettystream": "^0.1.3",
     "chalk": "^1.1.1",
     "concat-stream": "^1.5.1",


### PR DESCRIPTION
- Eliminates annoying dependency on developer tools to install (and compile) bunyan just to be able to pretty-print logs
- Extracts minimal log record generation from bunyan.