### PR TITLE
Ensure checkNodeModules always returns a promise

### DIFF
--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -72,6 +72,8 @@ function createWebtaskCreator(args, options) {
                         });
                 });
         }
+
+        return Promise.resolve([]);
     }
 
 


### PR DESCRIPTION
Add a default return value of a promise for an empty array to `checkNodeModules`. The empty array is to be consistent with the return values from the other 2 returns in this function, which both return an array of modules.

Fixes #134