### PR TITLE
Simplify profile option parsing

### DIFF
--- a/bin/_plugins/profile.js
+++ b/bin/_plugins/profile.js
@@ -31,13 +31,7 @@ function sandboxFromArguments(args, options) {
 
         if (args.token) {
             if (args.profile && !options.allowProfile) return resolve(new Cli.error.invalid('--profile should not be specified with custom tokens'));
-
-            var sandboxOptions = {
-                onBeforeRequest,
-                url: args.url || 'https://webtask.it.auth0.com',
-            };
-
-            if (args.container && args.token) {
+            if (args.container && args.url) {
                 try {
                     return resolve(Sandbox.init({
                         onBeforeRequest,
@@ -49,17 +43,7 @@ function sandboxFromArguments(args, options) {
                     return reject(e);
                 }
             }
-
-            if (args.container) sandboxOptions.container = args.container;
-
-            try {
-                return resolve(Sandbox.fromToken(args.token, sandboxOptions));
-            } catch (e) {
-                return reject(e);
-            }
         }
-
-        if (args.url) return reject(Cli.error.invalid('--token must be specified with --url'));
 
         var config = new ConfigFile();
         var profile$ = config.load()
@@ -88,6 +72,8 @@ function sandboxFromArguments(args, options) {
 
         function onProfileLoaded(profile) {
             if (args.container) profile.container = args.container;
+            if (args.url) profile.url = args.url;
+            if (args.token) profile.token = args.token;
 
             return profile;
         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",


### PR DESCRIPTION
This simplifies the logic of providing profile parameters through the command line: 

1. Url, container, and token from the profile specified with `--profile` (or a default profile if none is specified) are loaded. 
2. The are overridden with any or all of `--url`, `--token`, `--container` settings from command line.