### PR TITLE
Support for getting JWT tokens from an authorization server

### DIFF
--- a/bin/_plugins/profile.js
+++ b/bin/_plugins/profile.js
@@ -45,6 +45,7 @@ function onBeforeHandler(context) {
                 .login({ 
                     container: args.profile.container, 
                     admin: args.profile.openid.scopes.indexOf('wt:admin') > -1,
+                    auth0: args.profile.openid.auth0,
                     profileName: args.profile.name,
                     requestedScopes: args.profile.openid.scope,
                 })

--- a/bin/profile/init.js
+++ b/bin/profile/init.js
@@ -21,6 +21,11 @@ module.exports = Cli.createCommand('init', {
             dest: 'admin',
             type: 'boolean',
         },
+        'auth0': {
+            description: 'Intialize Auth0 account profile',
+            dest: 'auth0',
+            type: 'boolean',
+        },
     },
     params: {
         'email_or_phone': {
@@ -92,7 +97,7 @@ function handleProfileInit(args) {
 // Private helper functions
 
 function detectAuthMode(args) {
-    return UserAuthenticator.create(args.url)
+    return UserAuthenticator.create(args.url, args.auth0)
         .then(userAuthenticator => {
             if (!userAuthenticator) {
                 if (args.admin) {
@@ -100,7 +105,12 @@ function detectAuthMode(args) {
                 }
                 return getVerifiedProfile(args);
             }
-            return userAuthenticator.login({ container: args.container, admin: args.admin });
+            else {
+                if (args.auth0 && !args.container) {
+                    throw Cli.error.invalid('When --auth0 is specified, the --container must also be provided.');
+                }
+            }
+            return userAuthenticator.login({ auth0: args.auth0, container: args.container, admin: args.admin });
         });
 }
 

--- a/bin/profile/init.js
+++ b/bin/profile/init.js
@@ -105,10 +105,8 @@ function detectAuthMode(args) {
                 }
                 return getVerifiedProfile(args);
             }
-            else {
-                if (args.auth0 && !args.container) {
-                    throw Cli.error.invalid('When --auth0 is specified, the --container must also be provided.');
-                }
+            else if (args.auth0 && !args.container) {
+                throw Cli.error.invalid('When --auth0 is specified, the --container must also be provided.');
             }
             return userAuthenticator.login({ auth0: args.auth0, container: args.container, admin: args.admin });
         });

--- a/bin/token/create.js
+++ b/bin/token/create.js
@@ -119,6 +119,11 @@ module.exports = Cli.createCommand('create', {
 
 function handleTokenCreate(args) {
     var profile = args.profile;
+
+    if (profile.securityVersion !== 'v1') {
+        throw Cli.error.invalid('The `wt token create` command is not supported in the target service security configuration.');
+    }
+
     var claims = _.pick(_.pickBy(args, v => v !== null), Object.keys(RAW_CLAIMS));
     
     if (claims['code-url']) {

--- a/bin/token/create.js
+++ b/bin/token/create.js
@@ -121,7 +121,7 @@ function handleTokenCreate(args) {
     var profile = args.profile;
 
     if (profile.securityVersion !== 'v1') {
-        throw Cli.error.invalid('The `wt token create` command is not supported in the target service security configuration.');
+        throw Cli.error.invalid('The `wt token create` command is not supported by the target service security configuration.');
     }
 
     var claims = _.pick(_.pickBy(args, v => v !== null), Object.keys(RAW_CLAIMS));

--- a/bin/token/inspect.js
+++ b/bin/token/inspect.js
@@ -1,6 +1,7 @@
 var Cli = require('structured-cli');
 var Decode = require('jwt-decode');
 var PrintTokenDetails = require('../../lib/printTokenDetails');
+var PrintWebtaskDetails = require('../../lib/printWebtaskDetails');
 
 
 module.exports = Cli.createCommand('inspect', {
@@ -44,6 +45,11 @@ module.exports = Cli.createCommand('inspect', {
 
 function handleTokenInspect(args) {
     var profile = args.profile;
+
+    if (profile.securityVersion !== 'v1') {
+        throw Cli.error.invalid('The `wt token inspect` command is not supported in the target service security configuration.');
+    }
+
     var claims;
 
     try {
@@ -67,8 +73,11 @@ function handleTokenInspect(args) {
     function onTokenData(data) {
         if (args.output === 'json') {
             console.log(JSON.stringify(data, null, 2));
-        } else {
+        } else if (data.token) {
             PrintTokenDetails(data);
+        }
+        else {
+            PrintWebtaskDetails(data);
         }
     }
 }

--- a/bin/token/inspect.js
+++ b/bin/token/inspect.js
@@ -47,7 +47,7 @@ function handleTokenInspect(args) {
     var profile = args.profile;
 
     if (profile.securityVersion !== 'v1') {
-        throw Cli.error.invalid('The `wt token inspect` command is not supported in the target service security configuration.');
+        throw Cli.error.invalid('The `wt token inspect` command is not supported by the target service security configuration.');
     }
 
     var claims;

--- a/bin/token/revoke.js
+++ b/bin/token/revoke.js
@@ -34,7 +34,7 @@ function handleTokenRevoke(args) {
     var profile = args.profile;
 
     if (profile.securityVersion !== 'v1') {
-        throw Cli.error.invalid('The `wt token revoke` command is not supported in the target service security configuration.');
+        throw Cli.error.invalid('The `wt token revoke` command is not supported by the target service security configuration.');
     }
     
     return profile.revokeToken(args.subject)

--- a/bin/token/revoke.js
+++ b/bin/token/revoke.js
@@ -32,6 +32,10 @@ module.exports = Cli.createCommand('revoke', {
 
 function handleTokenRevoke(args) {
     var profile = args.profile;
+
+    if (profile.securityVersion !== 'v1') {
+        throw Cli.error.invalid('The `wt token revoke` command is not supported in the target service security configuration.');
+    }
     
     return profile.revokeToken(args.subject)
         .catch(function (err) {

--- a/lib/printTokenDetails.js
+++ b/lib/printTokenDetails.js
@@ -11,7 +11,7 @@ function printTokenDetails(claims, options) {
 
     var keys = Object.keys(claims).sort();
     keys.forEach(function (key) {
-        if (key == 'meta') return;
+        if (key == 'meta' || !claims[key]) return;
         var name = 'Token.' + key + ':';
         console.log(Chalk.blue(Pad(name, WIDTH)), claims[key]);
     });

--- a/lib/userAuthenticator.js
+++ b/lib/userAuthenticator.js
@@ -24,10 +24,11 @@ function UserAutenticator (config) {
 
 // Discover whether WT deployment supports auth v2 and if so create
 // UserAuthenticator instance for it
-UserAutenticator.create = function (sandboxUrl) {
+UserAutenticator.create = function (sandboxUrl, auth0) {
     // TODO, tjanczuk, remove the following line when v2 auth exits beta
-    // Until then, it is an experimental feature enabled with AUTH_MODE=v2 env var.
-    if (process.env.AUTH_MODE !== 'v2') return Promise.resolve(null);
+    // Until then, it is an experimental feature enabled with AUTH_MODE=v2 env var
+    // or use of --auth0 switch.
+    if (process.env.AUTH_MODE !== 'v2' && !auth0) return Promise.resolve(null);
 
     var descriptionUrl = Url.parse(sandboxUrl);
     descriptionUrl.pathname = '/api/description';
@@ -94,11 +95,21 @@ UserAutenticator.prototype._authorizationFlow =  function (options) {
     var port = 8722 + Math.floor(6 * Math.random());
     var redirectUri = `http://127.0.0.1:${port}`;
     var requestedScopes = [ 'openid', 'offline_access' ];
-    if (options.container) {
-        requestedScopes.push(`wt:owner:${options.container}`);
+    var audience;
+    if (options.auth0) {
+        audience = Url.parse(self.audience || self.sandboxUrl);
+        audience.pathname += '/containers/' + options.container;
+        audience = Url.format(audience);
+        requestedScopes.push('wt:owner');
     }
-    if (options.admin) {
-        requestedScopes.push(`wt:admin`);
+    else {
+        audience = Url.format(Url.parse(self.audience || self.sandboxUrl));
+        if (options.container) {
+            requestedScopes.push(`wt:owner:${options.container}`);
+        }
+        if (options.admin) {
+            requestedScopes.push(`wt:admin`);
+        }
     }
     requestedScopes = requestedScopes.join(' ');
 
@@ -121,7 +132,7 @@ UserAutenticator.prototype._authorizationFlow =  function (options) {
         loginUrl.pathname = '/authorize';
         loginUrl.query = {
             redirect_uri: redirectUri,
-            audience: Url.format(Url.parse(self.audience || self.sandboxUrl)),
+            audience: audience,
             response_type: 'code',
             client_id: self.clientId,
             scope: requestedScopes,
@@ -207,7 +218,7 @@ UserAutenticator.prototype._processAccessTokenResponse = function(options, body,
     var isAdmin = scopes.indexOf('wt:admin') > -1;
     var container;
     if (options.container) {
-        if (isAdmin || scopes.indexOf(`wt:owner:${options.container}`) > -1) {
+        if (isAdmin || scopes.indexOf(`wt:owner:${options.container}`) > -1 || scopes.indexOf('wt:owner') > -1) {
             container = options.container;
         }
         else {
@@ -245,6 +256,7 @@ UserAutenticator.prototype._processAccessTokenResponse = function(options, body,
     profile.openid.audience = this.audience;
     profile.openid.client_id = this.clientId;
     profile.openid.refresh_token = profile.openid.refresh_token || this.refreshToken;
+    profile.openid.auth0 = options.auth0;
 
     return done ? done(null, profile) : profile;
 };

--- a/lib/validateCreateArgs.js
+++ b/lib/validateCreateArgs.js
@@ -26,11 +26,11 @@ function validateCreateArgs(args) {
 
         // Enforce legacy options are not used
 
-        if (args.params.length > 0) {
+        if (args.params && args.params.length > 0) {
             throw Cli.error.invalid('--param is not supported by the server');
         }
 
-        if (!args.merge) {
+        if (args.merge !== undefined && !args.merge) {
             throw Cli.error.invalid('--no-merge is not supported by the server');   
         }
 

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -163,7 +163,8 @@ function createWebtaskCreator(args, options) {
                 .set('Authorization', `Bearer ${profile.token}`)
                 .send(payload)
                 .ok(res => res.status === 200)
-                .then(res => new Sandbox.Webtask(profile, args.name, {
+                .then(res => new Sandbox.Webtask(profile, res.body.token, {
+                    name: args.name,
                     meta: res.body.meta,
                     webtask_url: res.body.webtask_url,
                 }));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "8.3.0",
+  "version": "9.0.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",
@@ -47,7 +47,7 @@
     "opn": "^4.0.2",
     "pad": "^1.0.0",
     "promptly": "^0.2.1",
-    "sandboxjs": "^4.0.0",
+    "sandboxjs": "^4.1.0",
     "semver": "^5.3.0",
     "structured-cli": "^1.0.5",
     "superagent": "^3.5.2",


### PR DESCRIPTION
This adds support to wt-cli to call Extend management APIs using tokens issued by an authorization server the Extend deployment is configured to trust. 

For webtask.io, this is an opt-in feature that must be enabled during profile initialization using the AUTH_MODE environment variable: 

```
AUTH_MODE=v2 wt init --url https://webtask.it.auth0.com
```

For Extend deployments supporting Auth0 identity, the feature is opted into using the --auth0 flag: 

```
wt init --auth0 --url https://sandbox.it.auth0.com --container {container_name}
```

Note that in case of Auth0, the contaier name must be explicitly specified since it must be known a priori when a request for an access token is issued to the authorization server. In case of webtask.io, the container name can be discovered from the access token itself in case it is not explicitly specified on the command line. 