### PR TITLE
Remove normalization of audience as URL

### DIFF
--- a/lib/userAuthenticator.js
+++ b/lib/userAuthenticator.js
@@ -103,7 +103,7 @@ UserAutenticator.prototype._authorizationFlow =  function (options) {
         requestedScopes.push('wt:owner');
     }
     else {
-        audience = Url.format(Url.parse(self.audience || self.sandboxUrl));
+        audience = self.audience || self.sandboxUrl;
         if (options.container) {
             requestedScopes.push(`wt:owner:${options.container}`);
         }
@@ -190,7 +190,6 @@ UserAutenticator.prototype._authorizationFlow =  function (options) {
 
     // Exchange authorization code for access token using PKCE
     function exchangeAuthorizationCode(code, done) {
-        
         var tokenUrl = Url.parse(self.authorizationServer);
         tokenUrl.pathname = '/oauth/token';
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",


### PR DESCRIPTION
This is to remove adding terminating slash to audience string in wt-cli. Audience should be treated as an opaque string. 