### PR TITLE
update sandboxjs to fix wt inspect in security v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",
@@ -47,7 +47,7 @@
     "opn": "^4.0.2",
     "pad": "^1.0.0",
     "promptly": "^0.2.1",
-    "sandboxjs": "^4.1.0",
+    "sandboxjs": "^4.2.2",
     "semver": "^5.3.0",
     "structured-cli": "^1.0.5",
     "superagent": "^3.5.2",


### PR DESCRIPTION
The https://github.com/auth0/sandboxjs/pull/31 must be taken first, and sandboxjs@4.2.2 published to npm.