### PR TITLE
Modifications to `wt ls` Command

### DIFF
--- a/bin/ls.js
+++ b/bin/ls.js
@@ -22,7 +22,7 @@ module.exports = Cli.createCommand('ls', {
             'limit': {
                 type: 'int',
                 description: 'Limit the results to this many named webtasks',
-                defaultValue: 10,
+                defaultValue: 100,
             },
         },
         'Filtering': {
@@ -56,6 +56,11 @@ module.exports = Cli.createCommand('ls', {
             'node8': {
                 description: 'List webtasks copied to Node 8 environment',
                 dest: 'node8',
+                type: 'boolean',
+            },
+            'verbose': {
+                description: 'Display full details',
+                dest: 'verbose',
                 type: 'boolean',
             }
 
@@ -100,7 +105,7 @@ function handleTokenCreate(args) {
                     url: webtask.url,
                 };
                 if (webtask.meta) {
-                    record.meta = webtask.meta
+                    record.meta = webtask.meta;
                 }
                 
                 if (args.showToken) record.token = json.token;
@@ -111,7 +116,7 @@ function handleTokenCreate(args) {
             console.log(JSON.stringify(output, null, 2));
         } else {
             _.forEach(webtasks, function (webtask) {
-                PrintWebtask(webtask, { details: args.details, token: args.showToken });
+                PrintWebtask(webtask, { details: args.details, token: args.showToken, verbose: args.verbose });
                 console.log();
             });
             
@@ -125,11 +130,12 @@ function handleTokenCreate(args) {
                 }
             } else {
                 if (webtasks.length === args.limit) {
-                    console.log(Chalk.green('Successfully listed named webtasks %s to %s. To list more try:'), Chalk.bold(args.offset + 1), Chalk.bold(args.offset + webtasks.length));
+                    console.log(Chalk.green('Successfully listed named webtasks %s to %s.\nTo list more try:'), Chalk.bold(args.offset + 1), Chalk.bold(args.offset + webtasks.length));
                     console.log(Chalk.bold('$ wt ls --offset %d'), args.offset + args.limit);
                 } else {
                     console.log(Chalk.green('Successfully listed named webtasks %s to %s.'), Chalk.bold(args.offset + 1), Chalk.bold(args.offset + webtasks.length));
                 }
+                console.log(Chalk.green('Use --verbose to display full details.'));
             }
         }
     }

--- a/lib/printWebtask.js
+++ b/lib/printWebtask.js
@@ -15,13 +15,13 @@ function printWebtask(webtask, options) {
     
     console.log(Chalk.blue(Pad('Name:', WIDTH)), Chalk.green(json.name));
     console.log(Chalk.blue(Pad('URL:', WIDTH)), webtask.url);
-    // console.log(Chalk.blue(Pad('Container:', WIDTH)), webtask.container);
+    
     
     if (options.token) {
         console.log(Chalk.blue(Pad('Token:', WIDTH)), webtask.token);
     }
 
-    if (webtask.meta) {
+    if (webtask.meta && options.verbose) {
         for (var m in webtask.meta) {
             console.log(Chalk.blue(Pad('Meta.' + m + ':', WIDTH)), webtask.meta[m]);
         }


### PR DESCRIPTION
## Stories: 
- https://auth0team.atlassian.net/browse/EX-761
- https://auth0team.atlassian.net/browse/EX-762

This change updates the default limit for listing webtasks to the API limit of 100. It also updates the default listing display to only show the name and url of each webtask. A new flag has been added `--verbose` that will cause the output to display meta values.

## Default Display Example
![screen shot 2018-05-09 at 11 14 20 am](https://user-images.githubusercontent.com/73120/39831720-2d068d14-537a-11e8-9eaf-74e03553c6ea.png)


## Verbose Display Example
![screen shot 2018-05-09 at 11 15 31 am](https://user-images.githubusercontent.com/73120/39831779-54a4a0f4-537a-11e8-9b46-b6ec4ca843ba.png)
