### PR TITLE
Make Auth v2 the default

### DIFF
--- a/lib/userAuthenticator.js
+++ b/lib/userAuthenticator.js
@@ -26,9 +26,11 @@ function UserAuthenticator (config) {
 // UserAuthenticator instance for it
 UserAuthenticator.create = function (sandboxUrl, auth0) {
     // TODO, tjanczuk, remove the following line when v2 auth exits beta
-    // Until then, it is an experimental feature enabled with AUTH_MODE=v2 env var
-    // or use of --auth0 switch.
-    if (process.env.AUTH_MODE !== 'v2' && !auth0) return Promise.resolve(null);
+    // we are defaulting to AUTHv2 here, we can revert to AUTHv1 using
+    // AUTH_MODE=v1 env var
+    // the use of --auth0 switch forces AUTHv2 as well.
+
+    if (process.env.AUTH_MODE === 'v1' && !auth0) return Promise.resolve(null);
 
     var descriptionUrl = Url.parse(sandboxUrl);
     descriptionUrl.pathname = '/api/description';

--- a/lib/userAuthenticator.js
+++ b/lib/userAuthenticator.js
@@ -25,10 +25,8 @@ function UserAuthenticator (config) {
 // Discover whether WT deployment supports auth v2 and if so create
 // UserAuthenticator instance for it
 UserAuthenticator.create = function (sandboxUrl, auth0) {
-    // TODO, tjanczuk, remove the following line when v2 auth exits beta
     // we are defaulting to AUTHv2 here, we can revert to AUTHv1 using
-    // AUTH_MODE=v1 env var
-    // the use of --auth0 switch forces AUTHv2 as well.
+    // AUTH_MODE=v1 env var the use of --auth0 switch forces AUTHv2 as well.
 
     if (process.env.AUTH_MODE === 'v1' && !auth0) return Promise.resolve(null);
 


### PR DESCRIPTION
This change modifies the create method of UserAuthenticator to default to Authentication v2 model.

This is related to #212