### PR TITLE
remove usage of module with license issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "code": "^4.0.0",
-    "eslint": "^4.5.0",
+    "eslint": "^5.3.0",
     "lab": "^11.1.0",
     "mailinator": "^1.0.2",
     "proxyquire": "^1.7.10",


### PR DESCRIPTION
Simply updating to the latest `eslint` will remove the offending module and it's no-good license