### PR TITLE
feat: make sure hooks are created with the disabled flag always set

### DIFF
--- a/bin/auth0_create.js
+++ b/bin/auth0_create.js
@@ -114,10 +114,7 @@ function handleCreate(args) {
         args.params = [];
         args.meta['auth0-extension'] = 'runtime';
         args.meta['auth0-extension-name'] = args.extensionName;
-
-        // If updating exising hook, preserve the enabled/disabled state
-        if (!claims || claims.meta['auth0-extension-disabled'])
-            args.meta['auth0-extension-disabled'] = '1';
+        args.meta['auth0-extension-disabled'] = claims ? claims.meta['auth0-extension-disabled'] : '1';
 
         // If wt-compiler specified explicitly, use it. Otherwise use the default per hook type.
         if (!args.meta['wt-compiler'])
@@ -132,7 +129,7 @@ function handleCreate(args) {
             action: 'created', 
             onOutput: function (log, build, url) {
                 var action = claims ? 'updated' : 'created';
-                var state = args.meta['auth0-extension-disabled'] ? 'disabled' : 'enabled';
+                var state = args.meta['auth0-extension-disabled'] === "1" ? 'disabled' : 'enabled';
                 log(Chalk.green('Auth0 hook ' + action + ' in ' + state + ' state.') + 
                     (state == 'disabled' ? (' To enable this hook to run in production, call:\n\n'
                     + Chalk.green('$ auth0 enable ' + args.name)) : ''));

--- a/bin/auth0_ls.js
+++ b/bin/auth0_ls.js
@@ -83,7 +83,7 @@ function handleListAuth0Extensions(args) {
             var record = {
                 name: json.name,
                 type: args.extensionName || (webtask.meta && webtask.meta['auth0-extension-name']) || 'N/A',
-                enabled: !!(webtask.meta && !webtask.meta['auth0-extension-disabled'])
+                enabled: !!(webtask.meta && webtask.meta['auth0-extension-disabled'] !== "1")
             };                        
             if (!types[record.type]) {
                 types[record.type] = [ record ];

--- a/bin/auth0_toggle.js
+++ b/bin/auth0_toggle.js
@@ -26,10 +26,10 @@ function createHandleUpdate(action) {
 
         var profile = args.profile;
 
-        return profile.inspectWebtask({ 
-            name: args.name, 
+        return profile.inspectWebtask({
+            name: args.name,
             decrypt: true,
-            meta: true 
+            meta: true
         })
         .then(onClaims);
 
@@ -40,9 +40,9 @@ function createHandleUpdate(action) {
             var extensionName = claims.meta['auth0-extension-name'];
             if (!extensionName)
                 return Cli.error.invalid('The ' + args.name + ' webtask is not a an Auth0 hook.');
-            if (action === 'enable' && !claims.meta['auth0-extension-disabled'])
+            if (action === 'enable' && claims.meta['auth0-extension-disabled'] !== "1")
                 return console.log(Chalk.green('The ' + args.name + ' (' + extensionName + ') hook is already enabled.'));
-            if (action === 'disable' && claims.meta['auth0-extension-disabled'])
+            if (action === 'disable' && claims.meta['auth0-extension-disabled'] === "1")
                 return console.log(Chalk.green('The ' + args.name + ' (' + extensionName + ') hook is already disabled.'));
 
             if (action === 'disable') {
@@ -61,7 +61,7 @@ function createHandleUpdate(action) {
                 }).then(function (webtasks) {
                     var toDisable = [];
                     webtasks.forEach(function (wt) {
-                        if (!wt.meta['auth0-extension-disabled']) {
+                        if (wt.meta['auth0-extension-disabled'] !== "1") {
                             toDisable.push(toggleExtension(wt.toJSON().name, false));
                         }
                     });
@@ -87,11 +87,11 @@ function createHandleUpdate(action) {
         function adjustExtensionClaims(claims, enable) {
             if (enable) {
                 console.log('Enabling hook ' + claims.jtn + '.');
-                delete claims.meta['auth0-extension-disabled'];
+                claims.meta['auth0-extension-disabled'] = '0';
             }
             else {
                 console.log('Disabling hook ' + claims.jtn + '.');
-                claims.meta['auth0-extension-disabled'] = '1';   
+                claims.meta['auth0-extension-disabled'] = '1';
             }
             ['jti','ca','iat','webtask_url'].forEach(function (c) { delete claims[c]; });
             return claims;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-cli",
-  "version": "12.2.0",
+  "version": "12.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/ggoodman",
     "twitter": "filearts"
   },
-  "version": "12.2.0",
+  "version": "12.3.0",
   "description": "Webtask Command Line Interface",
   "tags": [
     "nodejs",


### PR DESCRIPTION
### Description

Creates webtasks with the disabled flag always set.

### References

https://auth0team.atlassian.net/browse/ESD-21604

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
