### PR TITLE
Use the http proxy for all http requests

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -8,6 +8,8 @@ const Superagent = require('superagent');
 const Wrap = require('linewrap');
 const _ = require('lodash');
 
+require('superagent-proxy')(Superagent)
+
 const ENSURE_AVAILABLE_TIMEOUT = 1000 * 60 * 5;
 const ENSURE_AVAILABLE_INTERVAL = 1000 * 5;
 const UNPKG_URL = 'https://unpkg.com';
@@ -103,7 +105,12 @@ function parseSpec(spec) {
 function resolveSpec(module) {
     const spec = `${ module.name }@${ module.range }`;
     const url = `${ UNPKG_URL }/${ spec }/package.json`;
-    const request = Superagent.get(url);
+
+    let request = Superagent.get(url);
+    const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+    if (proxy) {
+        request = request.proxy(proxy);
+    }
 
     return Sandbox.issueRequest(request)
         .catch(() => {

--- a/lib/userAuthenticator.js
+++ b/lib/userAuthenticator.js
@@ -10,6 +10,8 @@ var Decode = require('jwt-decode');
 var Assert = require('assert');
 var Crypto = require('crypto');
 
+require('superagent-proxy')(Superagent)
+
 module.exports = UserAuthenticator;
 
 function UserAuthenticator (config) {
@@ -32,8 +34,15 @@ UserAuthenticator.create = function (sandboxUrl, auth0) {
 
     var descriptionUrl = Url.parse(sandboxUrl);
     descriptionUrl.pathname = '/api/description';
-    return Superagent
+    let request = Superagent
         .get(Url.format(descriptionUrl))
+
+    const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+    if (proxy) {
+        request = request.proxy(proxy);
+    }
+
+    request
         .ok(res => res.status < 500)
         .then(res => {
             if (res.status === 200 && res.body && res.body.authorization_server) {
@@ -66,8 +75,15 @@ UserAuthenticator.prototype._refreshFlow = function (options) {
     var refreshUrl = Url.parse(this.authorizationServer);
     refreshUrl.pathname = '/oauth/token';
     var self = this;
-    return Superagent
+    let request = Superagent
         .post(Url.format(refreshUrl))
+
+    const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+    if (proxy) {
+        request = request.proxy(proxy);
+    }
+
+    request
         .send({
             grant_type: 'refresh_token',
             client_id: this.clientId,
@@ -193,8 +209,15 @@ UserAuthenticator.prototype._authorizationFlow =  function (options) {
         var tokenUrl = Url.parse(self.authorizationServer);
         tokenUrl.pathname = '/oauth/token';
 
-        return Superagent
+        let request = Superagent
             .post(Url.format(tokenUrl))
+
+        const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+        if (proxy) {
+            request = request.proxy(proxy);
+        }
+
+        request
             .send({
                 grant_type: 'authorization_code',
                 client_id: self.clientId,

--- a/lib/userVerifier.js
+++ b/lib/userVerifier.js
@@ -18,7 +18,12 @@ UserVerifier.prototype._runVerifierWebtask = function (query) {
     var request = Superagent
         .get(VERIFIER_URL)
         .query(query);
-    
+
+    const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+    if (proxy) {
+        request = request.proxy(proxy);
+    }
+
     return Sandbox.issueRequest(request)
         .get('body');
 };

--- a/lib/webtaskCreator.js
+++ b/lib/webtaskCreator.js
@@ -12,8 +12,9 @@ const Superagent = require('superagent');
 const Watcher = require('filewatcher');
 const _ = require('lodash');
 
-module.exports = createWebtaskCreator;
+require('superagent-proxy')(Superagent)
 
+module.exports = createWebtaskCreator;
 
 function createWebtaskCreator(args, options) {
     options = _.defaultsDeep({}, options, {
@@ -109,8 +110,14 @@ function createWebtaskCreator(args, options) {
     }
 
     function createSimpleWebtask(profile, generation) {
+        let request = Superagent.get(args.spec);
+        const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+        if (proxy) {
+            request = request.proxy(proxy);
+        }
+
         const codeOrUrl$ = args.capture
-            ?   Sandbox.issueRequest(Superagent.get(args.spec)).get('text')
+            ?   Sandbox.issueRequest(request).get('text')
             :   args.source === 'stdin'
                 ?   readStdin()
                 :   args.source === 'file'
@@ -162,8 +169,14 @@ function createWebtaskCreator(args, options) {
             if (args.host) payload.host = args.host;
             payload[(codeOrUrl.indexOf('http://') === 0 || codeOrUrl.indexOf('https://') === 0) ? 'url' : 'code'] = codeOrUrl;
 
-            return Superagent
+            let request = Superagent
                 .put(`${profile.url}/api/webtask/${profile.container}/${args.name}`)
+            const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+            if (proxy) {
+                request = request.proxy(proxy);
+            }
+
+            request
                 .set('Authorization', `Bearer ${profile.token}`)
                 .send(payload)
                 .ok(res => res.status === 200)
@@ -187,8 +200,15 @@ function createWebtaskCreator(args, options) {
     }
 
     function checkNodeVersion(profile) {
-        return Superagent
+        let request = Superagent
             .post(`${profile.url}/api/run/${profile.container}`)
+
+        const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+        if (proxy) {
+            request = request.proxy(proxy);
+        }
+
+       request
             .set('Authorization', `Bearer ${profile.token}`)
             .send(`module.exports = cb => cb(null, { version: process.version.replace(/^v/,'') });`)
             .ok(res => res.status === 200)


### PR DESCRIPTION
### Description

Expands HTTP Proxy usage to all HTTP requests. This is useful in cases where HTTP traffic is required to proxy through a content filter or similar proxy.

### Testing

Start an HTTP proxy:

```
docker run -d --name squid-container -e TZ=UTC -p 3128:3128 ubuntu/squid:5.2-22.04_beta
```

Configure the proxy:

```
export HTTP_PROXY=http://localhost:3128
```

Confirm wt-cli commands work as expected.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
