### PR TITLE
Fix netmask critical vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5060,8 +5060,8 @@
       "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.1.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "nice-try": {
@@ -5307,7 +5307,7 @@
         "co": "^4.6.0",
         "degenerator": "^1.0.4",
         "ip": "^1.1.5",
-        "netmask": "^1.0.6",
+        "netmask": "^2.0.1",
         "thunkify": "^2.1.2"
       }
     },


### PR DESCRIPTION
https://github.com/auth0/wt-cli/security/dependabot/26

The breaking change that triggered the version bump is to stop treating IPs with less than 4 octets as valid. As long as we don't pass in shortened/invalid IPs this should be fine.